### PR TITLE
[feat] 공통 응답구조, exception handler 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	runtimeOnly 'mysql:mysql-connector-java:8.0.32'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/aladin/aladinserver/common/CustomException.java
+++ b/src/main/java/com/aladin/aladinserver/common/CustomException.java
@@ -1,0 +1,15 @@
+package com.aladin.aladinserver.common;
+
+public class CustomException extends RuntimeException {
+
+        private final ErrorCode errorCode;
+
+        public CustomException(ErrorCode errorCode) {
+            super(errorCode.getMessage());
+            this.errorCode = errorCode;
+        }
+
+        public ErrorCode getErrorCode() {
+            return errorCode;
+        }
+}

--- a/src/main/java/com/aladin/aladinserver/common/ErrorCode.java
+++ b/src/main/java/com/aladin/aladinserver/common/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.aladin.aladinserver.common;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않은 메소드입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/aladin/aladinserver/common/SuccessCode.java
+++ b/src/main/java/com/aladin/aladinserver/common/SuccessCode.java
@@ -1,0 +1,24 @@
+package com.aladin.aladinserver.common;
+
+import org.springframework.http.HttpStatus;
+
+public enum SuccessCode {
+
+    OK(HttpStatus.OK, "요청이 성공했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    private SuccessCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/aladin/aladinserver/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/aladin/aladinserver/controller/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.aladin.aladinserver.controller;
+
+import com.aladin.aladinserver.common.CustomException;
+import com.aladin.aladinserver.controller.response.AladinResponse;
+import com.aladin.aladinserver.common.ErrorCode;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public AladinResponse<Void> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        return AladinResponse.fail(ErrorCode.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(CustomException.class)
+    public AladinResponse<Void> handleCustomException(CustomException e) {
+        return AladinResponse.fail(e.getErrorCode());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public AladinResponse<Void> handleException(Exception e) {
+        return AladinResponse.fail(ErrorCode.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/aladin/aladinserver/controller/response/AladinResponse.java
+++ b/src/main/java/com/aladin/aladinserver/controller/response/AladinResponse.java
@@ -1,0 +1,50 @@
+package com.aladin.aladinserver.controller.response;
+
+
+import com.aladin.aladinserver.common.ErrorCode;
+import com.aladin.aladinserver.common.SuccessCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public class AladinResponse<T> {
+
+    private final int code;
+    private final String message;
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)//null이 아닌것만(nonull)을 응답에 포함하겠다
+    private T data;
+
+    public AladinResponse(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public AladinResponse(int code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> AladinResponse<T> success(SuccessCode success) {
+        return new AladinResponse<>(success.getHttpStatus().value(), success.getMessage());
+    }
+
+
+    public static <T> AladinResponse<T> success(SuccessCode success, T data) {
+        return new AladinResponse<>(success.getHttpStatus().value(), success.getMessage(), data);
+    }
+
+    public static <T> AladinResponse<T> fail(ErrorCode error) {
+        return new AladinResponse<>(error.getHttpStatus().value(), error.getMessage());
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=aladinserver


### PR DESCRIPTION
## Related Issue 📌
close #3 

## Description ✔️
- apiresponse와 Exception handler를 추가했습니다.

## To Reviewers
원래는 core(엔티티)단 예외와 api, service 예외를 분리해야 합니다.
합세여서 가장 간단하게 만들었습니다.